### PR TITLE
update registration exercise for image orientation

### DIFF
--- a/notebooks/Reg/sirf_registration.ipynb
+++ b/notebooks/Reg/sirf_registration.ipynb
@@ -23,8 +23,9 @@
    "source": [
     "## Copyright\n",
     "\n",
-    "Author: Richard Brown\n",
-    "First version: 3rd April 2019\n",
+    "Author: Richard Brown  \n",
+    "First version: 3rd April 2019  \n",
+    "Second version: 8th June 2020  \n",
     "\n",
     "CCP PETMR Synergistic Image Reconstruction Framework (SIRF)\n",
     "Copyright 2019 University College London.\n",
@@ -74,7 +75,7 @@
    "outputs": [],
    "source": [
     "#%% First define some handy function definitions\n",
-    "# To make subsequent code cleaner, we have a few functions here. You can ignore\n",
+    "# To make subsequent code cleaner, we have a few functions here. You can\n",
     "# ignore them when you first see this demo.\n",
     "# They have (minimal) documentation using Python docstrings such that you \n",
     "# can do for instance \"help(imshow)\"\n",
@@ -160,7 +161,82 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Set up the registration object"
+    "## A little word about image orientation\n",
+    "\n",
+    "An image will needs information in order to be able to place it in the real world. This information encodes things such as voxel sizes, orientation and offset or origin (where the image starts). The geometrical information for any SIRF image can be extracted with `get_geometrical_info`.\n",
+    "\n",
+    "Let's have a look at the direction matrix and offset for our two example images:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Ref\n",
+    "ref_geom_info = ref.get_geometrical_info()\n",
+    "ref_direction_matrix = ref_geom_info.get_direction_matrix()\n",
+    "print(\"printing ref direction matrix\\n\", ref_direction_matrix)\n",
+    "ref_offset = ref_geom_info.get_offset()\n",
+    "print(\"printing ref offset\\n\", ref_offset)\n",
+    "# Flo\n",
+    "flo_geom_info = flo.get_geometrical_info()\n",
+    "flo_direction_matrix = flo_geom_info.get_direction_matrix()\n",
+    "print(\"\\nprinting flo direction matrix\\n\", flo_direction_matrix)\n",
+    "flo_offset = flo_geom_info.get_offset()\n",
+    "print(\"printing flo offset\\n\", flo_offset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So what have we learnt here? Well, if a direction matrix were identity, then our image would be in LPS format (left-posterior-superior). We can see that our first image is therefore RAS, and our second is LSA.\n",
+    "\n",
+    "This means that our `imshow` above is misleading. It uses `as_array`, which returns the underlying data \"as is\", without any regard for the image orientation. If we wanted to display our second image such that it's orientation matched the first (RAS), then we would need permute our 2nd and 3rd axes (such that LSA->LAS), and then flip our first axis (LAS->RAS). Let's give that a go now:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flo_array = flo.as_array()\n",
+    "# transpose (LSA->LAS)\n",
+    "flo_array = numpy.transpose(flo_array, (0, 2, 1))\n",
+    "# flip (LAS->RAS)\n",
+    "flo_array = numpy.flip(flo_array, 0)\n",
+    "\n",
+    "# Display\n",
+    "plt.figure()\n",
+    "plt.subplot(1,2,1)\n",
+    "imshow(ref.as_array()[ref_slice,:,:], 'Reference image, slice: %i' % ref_slice);\n",
+    "plt.subplot(1,2,2)\n",
+    "imshow(flo_array[flo_slice,:,:], 'Floating image, slice: %i' % flo_slice);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Great! \n",
+    "\n",
+    "Hopefully you can convince yourself that, in spite of the misleading orientation of the first `imshow`, the images are actually facing the same direction. \n",
+    "\n",
+    "Now have a look at our offsets that we printed further up. These are quite different. We would therefore expect the rigid registration between these two images would result in little rotation, but quite a lot of translation. \n",
+    "\n",
+    "Let's have a look!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Back to registration!\n",
+    "\n",
+    "Ok, let's get back to the registration. Start by setting up the registration object."
    ]
   },
   {
@@ -257,6 +333,13 @@
     "numpy.set_printoptions(precision=3,suppress=True)\n",
     "TM = algo.get_transformation_matrix_forward()\n",
     "print(TM.as_array())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So as we predicted earlier, there is little rotation (close to identity in the top 3x3 of the matrix), and there is large translation (final column)."
    ]
   },
   {


### PR DESCRIPTION
Fixes https://github.com/SyneRBI/SIRF-Exercises/issues/44

Does so by explaining affine image orientation matrices. The reference image is in RAS, whilst the floating is in LSA, so show `numpy.transpose` and `numpy.flip` such that orientation of floating matches reference. Slightly confusing, but then so is image orientation...