### PR TITLE
Add requirements.txt with instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,13 +40,13 @@ Check our [README](README.md) for more information on usage.
 
 ## Installing SIRF and the exercises yourself
 
-You will need SIRF of course. Please check the [instructions on our wiki](https://github.com/CCPPETMR/SIRF/wiki/How-to-obtain-SIRF).
+You will need SIRF of course. Please check the [instructions on our wiki](https://github.com/SyneRBI/SIRF/wiki/How-to-obtain-SIRF).
 
 The SIRF-exercises themselves can just be downloaded, preferably via
 
     mkdir ~/devel
     cd ~/devel
-    git clone https://github.com/CCPPETMR/SIRF-Exercises
+    git clone https://github.com/SyneRBI/SIRF-Exercises
     cd SIRF-Exercises
 
 
@@ -55,19 +55,19 @@ adjusting the path to where you want to install the SIRF-Exercises of course.
 You will need to install the additional Python dependencies needed for the
 exercises also
 
-    python3 -m pip install --user -r requirements.txt
+    $SIRF_PYTHON_EXECUTABLE -m pip install --user -r requirements.txt
 
+where we used the environment variable created when you follow the `SIRF-SuperBuild` instructions to make
+sure that you use a Python version which is compatible with how you compiled SIRF.
 This will do a "user" install - if you'd prefer a system install omit the
 `--user` flag. If you don't know what this means, use the above command.
+
 Of course, if you've used (Ana)conda to install Python etc (and are sure
 SIRF was compiled with that Python version), you can use conda to install
-dependencies as well. In this case, you may have to manually install pip in
-your conda environment:
+dependencies as well. Or you could still choose to use conda's `pip` after
 
     conda install pip
 
-Note that we set an environment variable when you installed SIRF to make
-sure that you use a Python version which is compatible with how you compiled SIRF.
 
 After all this, you will need to do the steps indicated in the instructions above for the VM, after the `update_VM.sh` step.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,29 +47,29 @@ The SIRF-exercises themselves can just be downloaded, preferably via
     mkdir ~/devel
     cd ~/devel
     git clone https://github.com/CCPPETMR/SIRF-Exercises
+    cd SIRF-Exercises
 
 
 adjusting the path to where you want to install the SIRF-Exercises of course.
 
-Finally, you need the jupyter server. Check first if your system comes with the jupyter server
-by typing
+You will need to install the additional Python dependencies needed for the
+exercises also
 
-    jupyter --help
+    python3 -m pip install --user -r requirements.txt
 
+This will do a "user" install - if you'd prefer a system install omit the
+`--user` flag. If you don't know what this means, use the above command.
+Of course, if you've used (Ana)conda to install Python etc (and are sure
+SIRF was compiled with that Python version), you can use conda to install
+dependencies as well. In this case, you may have to manually install pip in
+your conda environment:
 
-If you need to install it, we currently recommend using `pip`. The following command
-should work for you
-
-    $SIRF_PYTHON_EXECUTABLE -m pip install jupyter
+    conda install pip
 
 Note that we set an environment variable when you installed SIRF to make
 sure that you use a Python version which is compatible with how you compiled SIRF.
 
-Of course, if you've used (Ana)conda to install Python etc (and are sure
-SIRF was compiled with that Python version), you can use conda to install
-jupyter as well.
-
-After all this, you will need to do the steps indicated in the instructions above for the VM.
+After all this, you will need to do the steps indicated in the instructions above for the VM, after the `update_VM.sh` step.
 
 ### Updating the exercises after installation
 
@@ -78,7 +78,6 @@ to the exercises, you might want to keep those. Merging your changes and any
 "upstream" ones is unfortunately a bit complicated
 due to the file format used by jupyter notebooks. The following should work
 
-    pip install --user nbstripout
     cd SIRF-Exercises
     nbstripout --install
     git config --global filter.nbstripout.extrakeys '

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Authors:
 - Johannes Mayer (MR exercises)
 - Richard Brown (PET and registration exercises)
 - Daniel Deidda and Palak Wadhwa (HKEM exercise)
+- Ashley Gillman (overall check and clean-up)
 
 This software is distributed under an open source license, see [LICENSE.txt](LICENSE.txt)
 for details.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,18 @@
+# Notebook dependencies
+jupyter
+numpy --only-binary=numpy
+scipy --only-binary=scipy
+matplotlib --only-binary=matplotlib
+numba --only-binary=numba
+  llvmlite --only-binary=llvmlite  # numba dependency
+h5py --only-binary=h5py
+nibabel
+  scikit-image --only-binary=scikit-image  # nibabel dependency
+  PyWavelets --only-binary=PyWavelets      # nibabel dependency
+  imageio --only-binary=imageio            # nibabel dependency
+brainweb>=1.5.1
+tqdm
+docopt
+
+# Developer dependencies
+nbstripout


### PR DESCRIPTION
Fix #40 
Partial #77 (still need VM and Docker installations)

I've re-listed all dependencies explicitly required by SIRF-Exercises, including those that are already required by SIRF (although not all transitive dependencies - just those needed for the notebooks). I think this is good practice in case (a) for some reason the requirements are removed in SIRF or (b) a special version is needed here - but am happy to omit if preferred.

I've tried to make any libraries I suspected had C/C++ linked code `--only-binary`, including some transitive dependencies. Again, not sure if this is desired here - I thought it might help with the Docker installation.

I've also included developer dependencies (`nbstripout`). If there were more I'd consider a separate `dev_requirements.txt`.