### PR TITLE
download_MR_data should download the MR data

### DIFF
--- a/scripts/download_MR_data.sh
+++ b/scripts/download_MR_data.sh
@@ -9,4 +9,4 @@
 # Copyright (C) 2021 CSIRO
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-"$SCRIPT_DIR/download_data.sh" -o -d "$1"
+"$SCRIPT_DIR/download_data.sh" -m -d "$1"


### PR DESCRIPTION
This slipped past tests because technically `-o` also does the MR - so it was just downloading too much.

I've re-ran all 4 scripts to double check.