### PR TITLE
Correct MR Notebook d

### DIFF
--- a/notebooks/MR/d_undersampled_reconstructions.ipynb
+++ b/notebooks/MR/d_undersampled_reconstructions.ipynb
@@ -356,7 +356,7 @@
    "source": [
     "# NOW LET'S LOOK WHICH PARTS ARE SAMPLED AND WHICH ARE LEFT OUT\n",
     "# kspace_encode_step_1 gives the phase encoding steps which were performed\n",
-    "which_pe = preprocessed_data.get_ISMRMRD_info ('kspace_encode_step_1')\n",
+    "which_pe = preprocessed_data.get_ISMRMRD_info('kspace_encode_step_1')\n",
     "\n",
     "print('The following Phase Encoding (PE) points were sampled: \\n')\n",
     "print(which_pe)"

--- a/notebooks/MR/d_undersampled_reconstructions.ipynb
+++ b/notebooks/MR/d_undersampled_reconstructions.ipynb
@@ -356,7 +356,7 @@
    "source": [
     "# NOW LET'S LOOK WHICH PARTS ARE SAMPLED AND WHICH ARE LEFT OUT\n",
     "# kspace_encode_step_1 gives the phase encoding steps which were performed\n",
-    "which_pe = preprocessed_data.get_info('kspace_encode_step_1')\n",
+    "which_pe = preprocessed_data.get_ISMRMRD_info ('kspace_encode_step_1')\n",
     "\n",
     "print('The following Phase Encoding (PE) points were sampled: \\n')\n",
     "print(which_pe)"
@@ -508,7 +508,7 @@
     "fig = plt.figure()\n",
     "plt.set_cmap('jet')\n",
     "for c in range(csm_array.shape[1]):\n",
-    "    ax = fig.add_subplot(2,num_channels//m2,c+1)\n",
+    "    ax = fig.add_subplot(2,num_channels//2,c+1)\n",
     "    ax.imshow(abs(csm_array[:,c,:]))\n",
     "    ax.set_title('Coil '+str(c+1))\n",
     "    ax.axis('off')\n",


### PR DESCRIPTION
Fixes #112 

- Corrected typo where `m2` was used instead of just the number `2`
- Updated change of method name `get_info` to `get_ISMRMRD_info()` 