### PR TITLE
add option to download_data.sh to specify working_dir 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ lib/sirf_exercises/data_path.py
 
 # Nix temp
 _build
+
+# working directory
+working_dir

--- a/lib/sirf_exercises/__init__.py
+++ b/lib/sirf_exercises/__init__.py
@@ -38,7 +38,7 @@ def exercises_data_path(*data_type):
     return os.path.join(data_path, *data_type)
 
 
-def cd_to_working_dir(*subfolders):
+def cd_to_working_dir(*subfolders, base_dir=None):
     '''
     Creates and changes the current directory to a working directory for the
     current exercise, based on the argument(s). If multiple
@@ -50,6 +50,9 @@ def cd_to_working_dir(*subfolders):
     subfolders: the path will include this.
     Multiple arguments can be given for nested subdirectories.
     '''
-    working_dir = exercises_data_path('working_folder', *subfolders)
+    if base_dir is None:
+        working_dir = exercises_data_path('working_folder', *subfolders)
+    else:
+        working_dir = os.path.join(os.path.abspath(base_dir), *subfolders)
     os.makedirs(working_dir, exist_ok=True)
     os.chdir(working_dir)

--- a/lib/sirf_exercises/__init__.py
+++ b/lib/sirf_exercises/__init__.py
@@ -47,8 +47,9 @@ def cd_to_working_dir(*subfolders, base_dir=None):
     Implementation detail: this is defined as
     {exercises_data_path()}/working_folder/{subfolders[0]}/{subfolders[1]}/...
 
-    subfolders: the path will include this.
-    Multiple arguments can be given for nested subdirectories.
+    :param subfolders: the path will include this. Multiple arguments can be given for nested subdirectories.
+    :param base_dir: base directory for the working directory.
+    :type base_dir: string or path object, default what returned by `exercises_data_path`
     '''
     if base_dir is None:
         working_dir = exercises_data_path('working_folder', *subfolders)

--- a/lib/sirf_exercises/__init__.py
+++ b/lib/sirf_exercises/__init__.py
@@ -46,8 +46,15 @@ def cd_to_working_dir(*subfolders):
 
     Implementation detail: this is defined as
     {exercises_data_path()}/working_folder/{subfolders[0]}/{subfolders[1]}/...
+
+    subfolders: the path will include this.
+    Multiple arguments can be given for nested subdirectories.
     '''
-    working_dir = exercises_data_path('working_folder', *subfolders)
+    try:
+        from .working_path import working_dir
+        working_dir = os.path.join(working_dir, *subfolders)
+    except ImportError:
+        working_dir = exercises_data_path('working_folder', *subfolders)
     os.makedirs(working_dir, exist_ok=True)
     os.chdir(working_dir)
 

--- a/lib/sirf_exercises/__init__.py
+++ b/lib/sirf_exercises/__init__.py
@@ -38,7 +38,7 @@ def exercises_data_path(*data_type):
     return os.path.join(data_path, *data_type)
 
 
-def cd_to_working_dir(*subfolders, base_dir=None):
+def cd_to_working_dir(*subfolders):
     '''
     Creates and changes the current directory to a working directory for the
     current exercise, based on the argument(s). If multiple
@@ -46,14 +46,8 @@ def cd_to_working_dir(*subfolders, base_dir=None):
 
     Implementation detail: this is defined as
     {exercises_data_path()}/working_folder/{subfolders[0]}/{subfolders[1]}/...
-
-    :param subfolders: the path will include this. Multiple arguments can be given for nested subdirectories.
-    :param base_dir: base directory for the working directory.
-    :type base_dir: string or path object, default what returned by `exercises_data_path`
     '''
-    if base_dir is None:
-        working_dir = exercises_data_path('working_folder', *subfolders)
-    else:
-        working_dir = os.path.join(os.path.abspath(base_dir), *subfolders)
+    working_dir = exercises_data_path('working_folder', *subfolders)
     os.makedirs(working_dir, exist_ok=True)
     os.chdir(working_dir)
+

--- a/scripts/download_data.sh
+++ b/scripts/download_data.sh
@@ -62,7 +62,6 @@ DATA_PATH="${DEST_DIR:-"${REPO_DIR}"/data}"   # if no DEST_DIR, use REPO_DIR/dat
 DOWNLOAD_DIR="${DOWNLOAD_DIR:-"$DATA_PATH"}"  # if no DOWNLOAD_DIR, use DEST_DIR
 DATA_PATH="$(canonicalise "$DATA_PATH")"        # canonicalise
 DOWNLOAD_DIR="$(canonicalise "$DOWNLOAD_DIR")"  # canonicalise
-WORKING_DIR="$(canonicalise "$WORKING_DIR")"    # canonicalise
 echo Destination is \""$DATA_PATH"\"
 echo Download location is \""$DOWNLOAD_DIR"\"
 
@@ -200,6 +199,7 @@ fi
 
 if [[ -n "${WORKING_DIR}" ]]
 then
+  WORKING_DIR="$(canonicalise "$WORKING_DIR")"    # canonicalise
   echo "creating working_path.py in ${REPO_DIR}/lib/sirf_exercises/working_path.py"  
   cat <<EOF >"${REPO_DIR}/lib/sirf_exercises/working_path.py" 
 working_dir = '${WORKING_DIR}'


### PR DESCRIPTION
Allows to specify a base directory for `cd_to_working_dir`. If passed nothing it will use whatever is returned by `exercises_data_path`