### PR TITLE
Fix #105 - Untested!

### DIFF
--- a/scripts/download_data.sh
+++ b/scripts/download_data.sh
@@ -83,7 +83,7 @@ function check_md5 {
         return $retval
     else
         echo "Unable to check md5. Please install md5sum or md5"
-        exit 1
+        return 0
     fi
 }
 

--- a/scripts/download_data.sh
+++ b/scripts/download_data.sh
@@ -73,9 +73,11 @@ fi
 # check the md5, OSX compat
 function check_md5 {
     filename=$1
-    if [[ -e $(which md5sum) ]]; then
-        md5sum -c "${filename}.md5"
-    elif [[ -e $(which md5) ]]; then
+    if  command -v md5sum > /dev/null  2>&1
+    then
+        md5sum -c "${filename}.md5" > /dev/null  2>&1
+    elif command -v md5 > /dev/null  2>&1
+    then
         md5 -r "${filename}" > "${filename}.tmp.md5"
         diff -q "${filename}.tmp.md5" "${filename}.md5"
         retval=$?

--- a/scripts/download_data.sh
+++ b/scripts/download_data.sh
@@ -70,6 +70,23 @@ if [[ "$DO_OLD" ]]; then
     DO_MR='true'
 fi
 
+# check the md5, OSX compat
+function check_md5 {
+    filename=$1
+    if [[ -e $(which md5sum) ]]; then
+        md5sum -c "${filename}.md5"
+    elif [[ -e $(which md5) ]]; then
+        md5 -r "${filename}" > "${filename}.tmp.md5"
+        diff -q "${filename}.tmp.md5" "${filename}.md5"
+        retval=$?
+        rm "${filename}.tmp.md5"
+        return $retval
+    else
+        echo "Unable to check md5. Please install md5sum or md5"
+        exit 1
+    fi
+}
+
 # a function to download a file and check its md5
 # assumes that file.md5 exists
 function download {
@@ -78,7 +95,7 @@ function download {
     suffix="$3"
     if [ -r "$filename" ]
     then
-        if md5sum -c "${filename}.md5"
+        if check_md5 "${filename}"
         then
             echo "File exists and its md5sum is ok"
             return 0
@@ -91,7 +108,7 @@ function download {
     echo curl -L -o "$filename" "${URL}${filename}${suffix}"
     curl -L -o "$filename" "${URL}${filename}${suffix}"
 
-    if md5sum -c "${filename}.md5"
+    if check_md5 "${filename}"
     then
         echo "Downloaded file's md5sum is ok"
     else


### PR DESCRIPTION
OSX has md5, not md5sum. Unable to test Mac part.

Tested on Ubuntu:
  - download exists, finds MD5 correct
  - modify file, redownloads
  - hide `md5sum` command, fails saying "unable to check..."