### PR TITLE
Corrections for geometry notebook

### DIFF
--- a/notebooks/Geometry/a_geometry.ipynb
+++ b/notebooks/Geometry/a_geometry.ipynb
@@ -230,20 +230,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7c21112b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "RAH2LPH = [[-1, -1, -1, -1 ],\n",
-    "           [-1, -1, -1, -1 ],\n",
-    "           [ 1,  1,  1,  1 ],\n",
-    "           [ 1,  1,  1,  1 ]]\n",
+    "RAH2LPH = [[-1, 0, 0, 0 ],\n",
+    "           [ 0,-1, 0, 0 ],\n",
+    "           [ 0, 0, 1, 0 ],\n",
+    "           [ 0, 0, 0, 1 ]]\n",
     "\n",
-    "A_LPH = np.multiply(A_RAH, RAH2LPH)\n",
+    "A_LPH = np.matmul(RAH2LPH,A_RAH)\n",
     "print(A_LPH)"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "ebf18789",
    "metadata": {},
    "source": [
     "Note this affine matrix contains information about the pixel sizes (the scaling on the diagonal), the offset (the right column) and the image orientation.\n",

--- a/notebooks/Geometry/a_geometry.ipynb
+++ b/notebooks/Geometry/a_geometry.ipynb
@@ -244,7 +244,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ebf18789",
    "metadata": {},
    "source": [
     "Note this affine matrix contains information about the pixel sizes (the scaling on the diagonal), the offset (the right column) and the image orientation.\n",

--- a/notebooks/Geometry/a_geometry.ipynb
+++ b/notebooks/Geometry/a_geometry.ipynb
@@ -230,7 +230,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c21112b",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
Two corrections are applied. Fixes #136. 

- the coordinate transform between RAH and LPH was chosen wrong. 
- corrected vector normalisation. these are now consistent with the ones from the Nifti header print statement at the end.

