### PR TITLE
Initialize uniformWeights with BowsherWeights.copy()

### DIFF
--- a/notebooks/Synergistic/MAPEM_Bowsher.ipynb
+++ b/notebooks/Synergistic/MAPEM_Bowsher.ipynb
@@ -441,7 +441,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "uniformWeights=BowsherWeights\n",
+    "uniformWeights=BowsherWeights.copy()\n",
     "uniformWeights[:,:]=1\n",
     "# set \"self-weight\" of the voxel to zero\n",
     "uniformWeights[:,27//2]=0"


### PR DESCRIPTION
BowsherWeights and uniformWeights were being assigned to the same container.