### PR TITLE
Fix arguments for compute_nhoodIndVec function

### DIFF
--- a/notebooks/Synergistic/Solutions/Dual_PET_Answer-noMotion.ipynb
+++ b/notebooks/Synergistic/Solutions/Dual_PET_Answer-noMotion.ipynb
@@ -318,8 +318,8 @@
     "weights_amyl = update_bowsher_weights(amyl_prior,fdg_init_image,num_bowsher_neighbours)\n",
     "\n",
     "# compute indices of the neighbourhood\n",
-    "nhoodIndVec_fdg=compute_nhoodIndVec(fdg_init_image,weights_fdg)\n",
-    "nhoodIndVec_amyl=compute_nhoodIndVec(amyl_init_image,weights_amyl)"
+    "nhoodIndVec_fdg=compute_nhoodIndVec(fdg_init_image.shape,weights_fdg.shape)\n",
+    "nhoodIndVec_amyl=compute_nhoodIndVec(amyl_init_image.shape,weights_amyl.shape)"
    ]
   },
   {


### PR DESCRIPTION
Arguments of compute_nhoodIndVec(imageSize,weightsSize) function were not being passed with the .shape method.