### PR TITLE
remove --only-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,16 +2,16 @@
 jupyter
 ipywidgets
 ipympl
-numpy --only-binary=numpy
-scipy --only-binary=scipy
-matplotlib --only-binary=matplotlib
-numba --only-binary=numba
-  llvmlite --only-binary=llvmlite  # numba dependency
-h5py --only-binary=h5py
+numpy
+scipy
+matplotlib
+numba
+llvmlite  # numba dependency
+h5py
 nibabel
-  scikit-image --only-binary=scikit-image  # nibabel dependency
-  PyWavelets --only-binary=PyWavelets      # nibabel dependency
-  imageio --only-binary=imageio            # nibabel dependency
+scikit-image # nibabel dependency
+PyWavelets # nibabel dependency
+imageio # nibabel dependency
 brainweb>=1.5.1
 tqdm
 docopt


### PR DESCRIPTION
Removes `--only-binary` from the `requirements.txt` that make `conda` fail install with this file, see https://github.com/SyneRBI/SIRF-SuperBuild/actions/runs/3892212789/jobs/6645282809#step:7:2249