### PR TITLE
Add .devcontainer and environment.yml

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM synerbi/sirf:devel-service
+

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,0 @@
-FROM synerbi/sirf:devel-service
-

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+	"hostRequirements": {
+ 	  "cpus": 4,
+   	  "memory": "8gb",
+	  // currently need more than 32gb to get the image to build
+   	  "storage": "64gb"
+	},
+	"name": "SIRF-Exercises",
+
+	// "initializeCommand": "docker system prune --all --force",
+	
+	// make sure we run our entrypoint.sh (to create users etc)
+	"overrideCommand": false,
+
+	"build": { 
+		"context": "..",
+		"dockerfile": "Dockerfile"
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Comment to connect as root instead.
+	"remoteUser": "jovyan",
+
+        "postCreateCommand": "mamba env update --file environment.yml && scripts/download_data.sh",
+	// manual start of gadgetron, but commented-out as this is done in the service image
+        // "postStartCommand": "nohup bash -c 'gadgetron >& /tmp/gadgetron.log &'"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,12 +12,7 @@
 	
 	// make sure we run our entrypoint.sh (to create users etc)
 	"overrideCommand": false,
-
-	"build": { 
-		"context": "..",
-		"dockerfile": "Dockerfile"
-	},
-
+	"image": "synerbi/sirf:devel-service",
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 
@@ -27,11 +22,14 @@
 	// Comment to connect as root instead.
 	"remoteUser": "jovyan",
 
-        "postCreateCommand": "mamba env update --file environment.yml && scripts/download_data.sh",
+    "postCreateCommand": "bash ./.devcontainer/postCreateCommand.sh",
 	// manual start of gadgetron, but commented-out as this is done in the service image
         // "postStartCommand": "nohup bash -c 'gadgetron >& /tmp/gadgetron.log &'"
 
 	// Configure tool-specific properties.
 	// "customizations": {},
+	"extensions": ["ms-python.python",
+		"ms-toolsai.jupyter",
+		"ms-python.vscode-pylance"]
 
 }

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,3 +1,2 @@
-sed -i 's/\r$//' /workspaces/SIRF-Exercises/scripts/download_data.sh
 bash /workspaces/SIRF-Exercises/scripts/download_data.sh -m -p
 mamba env update --file environment.yml

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,3 @@
+sed -i 's/\r$//' /workspaces/SIRF-Exercises/scripts/download_data.sh
+bash /workspaces/SIRF-Exercises/scripts/download_data.sh -m -p
+mamba env update --file environment.yml

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.txt text
+*.md text
+*.yml text
+
+# Shell scripts should have LF
+*.sh text eol=lf
+*.csh text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.zip binary
+*.gz binary

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 # ChangeLog
+## xx.xx.xx
+* added `environment.yml` for `conda` users. This also installs CIL.
+* added a [`.devcontainer` folder](https://containers.dev/) which enables GitHub Codespaces as well as Visual Studio Code devcontainers.
+
 ## v3.4.0
 * change from jupyter notebook to lab
   - updated documentation

--- a/DocForParticipants.md
+++ b/DocForParticipants.md
@@ -5,7 +5,10 @@ This instruction contain documentation and links to get started with the exercis
 - [Start Here](#start-here)
 
 - [Start a jupyter notebook server for the SIRF exercises](#Start-a-jupyter-notebook-server-for-the-SIRF-exercises)
-    - [Using an Azure Client](#using-and-azure-client-(if-available))
+    - [Using the Cloud](#using-the-cloud)
+        - [Using GitHub Codespaces](#using-github-codespaces)
+        - [Using an Azure Client](#using-an-azure-client-if-available)
+        - [Using the STFC cloud](#using-an-stfc-cloud-instance-if-available)
     - [Using the VM](#using-the-vm)
     - [Using Docker](#using-docker)
     - [Using your own installed SIRF and SIRF-exercises](#using-your-own-installed-sirf-and-sirf-exercises )
@@ -21,7 +24,7 @@ This instruction contain documentation and links to get started with the exercis
 - [Appendix of useful info](#appendix)
 
 The SIRF documentation can be found [here](https://github.com/SyneRBI/SIRF/wiki/Software-Documentation).
-***The current version of these exercises needs SIRF v3.2.0 (SPECT needs v3.3.0 (pre-)release)***
+***The current version of these exercises needs SIRF v3.4.0.*** Some exercises could still work on SIRF v3.2.0 (SPECT needs v3.3.0).
 
 Documentation is in the form of MarkDown files (`*.md`), which are simple text files which you open from the Jupyter notebook, but they look nicer when browsing to [GitHub](https://github.com/SyneRBI/SIRF-Exercises/tree/master/).
 
@@ -54,15 +57,33 @@ Once you have SIRF and the exercises on your system, or access to a server with 
 
 The next sections contain instructions to start the Jupyter notebook server with the SIRF exercises for all the different installation options. In following steps, we will start a Gadgetron server and download data.
 
-## Start a jupyter notebook server for the SIRF exercises
-
 ***Warning:** these instructions are when using JupyterLab as opposed to the "classic" notebook
 interface. If you choose to use the classic interface, you will have to modify the notebooks
 marginally by replacing `%matplotlib widget` with `%matplotlib notebook`.
 See also the [iPython section](#ipython) below.
 
+## Start a jupyter notebook server for the SIRF exercises
 
-### Using an Azure client (if available)
+### Using the Cloud
+
+#### Using GitHub Codespaces
+
+GitHub allows creating a container in the cloud which you can access via your web browser, see the
+[GitHub Codespaces documentation](https://docs.github.com/en/codespaces/overview) for full information.
+The free allocation should be enough to get you familiar with SIRF.
+
+Note that the creation of the codespace will take around 5 minutes. This includes creation of the container,
+installation of all dependencies and downloading the example data.
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/SyneRBI/SIRF-Exercises)
+
+Some notes:
+- When selecting a kernel, please use the `conda` python (not `/usr/bin/python3`).
+- You might want to conserve some resources by manually
+[stopping a code space](https://docs.github.com/en/codespaces/developing-in-codespaces/stopping-and-starting-a-codespace),
+otherwise GitHub will stop it for you after a certain time-out. You can then restart the codespace to resume your work.
+
+#### Using an Azure client (if available)
 
 The web-address should be something like https://sirf1....cloudapp.azure.com:9999/. See local instructions of your training sessoin.
 *Do not forget the `https`*. You will need to accept the secure exception. The Jupyter notebook password is `virtual`.
@@ -70,7 +91,7 @@ The web-address should be something like https://sirf1....cloudapp.azure.com:999
 If the instructors tell you, you might have to create a terminal via the jupyter notebook and type `update_VM.sh`.
 Later in the course, you can use this terminal to start `gadgetron`.
 
-### Using an STFC Cloud instance (if available)
+#### Using an STFC Cloud instance (if available)
 Follow instructions given elsewhere.
 
 ### Using the VM
@@ -101,7 +122,7 @@ Please note that for at present (at least up to SIRF 3.4), you need to point you
 
 ### Using your own installed SIRF and SIRF-exercises 
 
-You have a jupyter server (as you followed the [installation instructions](INSTALL.md)) so just use
+You have a jupyter server and SIRF (as you followed the [installation instructions](INSTALL.md)), so just use
    ```bash
    cd /wherever/you/installed/it/SIRF-Exercises
    jupyter lab
@@ -117,7 +138,8 @@ Copy-paste in the terminal window can be tricky. Normally, you can shift+right c
 
 ## Start a Gadgetron server
 
-SIRF uses Gadgetron for MR reconstruction. You will need to start a "server" such that SIRF can communicate to it. Docker already starts this automatically, but if you are using anything else you need to start Gadgetron yourself.
+SIRF uses Gadgetron for MR reconstruction. You will need to start a "server" such that SIRF can communicate to it.
+Docker and GitHub Codespaces already start this automatically, but if you are using anything else you need to start Gadgetron yourself.
 
 Open a new terminal (for the Jupyter interface, see above) and type
 ```bash
@@ -130,7 +152,8 @@ You can kill the server at the end by going back to the terminal and pressing `C
 
 ## Getting the Data
 
-Some exercises use data that you will need. In the cloud and in Azure, we provide the data you need for the tests, but otherwise, you will need to download it.
+Some exercises use data that you will need. In the cloud (GitHub Codespaces, STFC cloude, Azure),
+we provide the data you need for the exercises, but otherwise, you will need to download it.
 There are download scripts available for that, available in the `SIRF-Exercises/scripts` folder. The introductory notebooks contain
 cells for running the script, but you can also do this from the command line (see above on how to start a terminal from Jupyter).
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,20 +32,18 @@ The SIRF-exercises themselves can just be downloaded, preferably via
 adjusting the path to where you want to install the SIRF-Exercises of course.
 
 You will need to install the additional Python dependencies needed for the
-exercises also
+exercises. If you've installed SIRF using a `conda` python environment, we recommend
+
+    conda env update -n <your_env_name> --file environment.yml
+
+If you didn't use `conda`, use
 
     $SIRF_PYTHON_EXECUTABLE -m pip install -r requirements.txt
 
 where we used the environment variable created when you follow the `SIRF-SuperBuild` instructions to make
-sure that you use a Python version which is compatible with how you compiled SIRF.
-
-Of course, if you've used (Ana)conda to install Python etc (and are sure
-SIRF was compiled with that Python version), you can use conda to install
-dependencies as well (except the brainweb module, at the time of writing).
-Or you could still choose to use conda's `pip` after
-
-    conda install pip
-
+sure that you use a Python version which is compatible with how you compiled SIRF. Please note that the
+`conda` environment includes dependencies (in particular [`cil`](https://github.com/TomographicImaging/CIL))
+which are not available with `pip`.
 
 After all this, you will need to do the steps indicated in the instructions above for the VM, after the `update_VM.sh` step.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,14 +7,14 @@ installation process therefore. Instructions below are for setting it up yoursel
 
 Author: Kris Thielemans
 
-An easy way to run the exercises is to use the SIRF Virtual Machine or a Docker image where
-SIRF has already been installed for you. To install SIRF and SIRF-Exercises with these methods, please read https://github.com/SyneRBI/SIRF/wiki/How-to-obtain-SIRF.
-
-Alternatively you can install SIRF yourself. Below are some brief instructions.
-
 The exercises use [Jupyter notebooks](http://jupyter-notebook-beginner-guide.readthedocs.io/en/latest/what_is_jupyter.html).
-These provide a nice GUI interface to Python. You need 2 components:
-The jupyter notebook server and a web browser to open it.
+These provide a nice GUI interface to Python. You need a few components:
+The jupyter notebook server and a web browser to open it, SIRF and the SIRF-Exercises.
+
+An easy way to run the exercises is to use a GitHub Codespace, the SIRF Virtual Machine or a Docker image where
+SIRF has already been installed for you. Please read https://github.com/SyneRBI/SIRF/wiki/How-to-obtain-SIRF.
+
+Alternatively you can install SIRF and the SIRF-Exercises yourself. Below are some brief instructions.
 
 
 ## Installing SIRF and the exercises yourself
@@ -32,7 +32,8 @@ The SIRF-exercises themselves can just be downloaded, preferably via
 adjusting the path to where you want to install the SIRF-Exercises of course.
 
 You will need to install the additional Python dependencies needed for the
-exercises. If you've installed SIRF using a `conda` python environment, we recommend
+exercises. This includes a Jupyter notebook server.
+If you've installed SIRF using a `conda` python environment, we recommend
 
     conda env update -n <your_env_name> --file environment.yml
 
@@ -45,7 +46,9 @@ sure that you use a Python version which is compatible with how you compiled SIR
 `conda` environment includes dependencies (in particular [`cil`](https://github.com/TomographicImaging/CIL))
 which are not available with `pip`.
 
-After all this, you will need to do the steps indicated in the instructions above for the VM, after the `update_VM.sh` step.
+**Warning:** At present, SIRF is not yet available via conda or pip. The above instructions therefore do not install SIRF itself.
+
+Next steps are in the [DocForParticipants.md](DocForParticipants.md).
 
 ### Updating the exercises after installation
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,19 @@ for details.
 
 # Links to documentation
 
-Full instructions on getting started is in our [documentation for participants](DocForParticipants.md). (Or use [this link to GitHub](https://github.com/SyneRBI/SIRF-Exercises/blob/master/DocForParticipants.md) for nice formatting, but do check which version of the exercises you are using).  
+Full instructions on getting started are in our [documentation for participants](DocForParticipants.md)
+(or use [this link to GitHub](https://github.com/SyneRBI/SIRF-Exercises/blob/master/DocForParticipants.md)
+for nice formatting, but do check which version of the exercises you are using). Despite the name,
+this documentation is also appropriate if you are trying these exercises on your own.
 *Gentle request*:
 If you are attending a course, ***please read this before the course.*** 
 
 Instructors should check our [documentation for instructors](https://github.com/SyneRBI/SIRF-Exercises/blob/master/DocForInstructors.md).
 
 Installation instructions when you do not use our cloud resources are in [INSTALL.md](INSTALL.md), but read the above links first.
+
+You can run the SIRF-Exercises in GitHub Codespaces, see [the section in the documentation](DocForParticipants.md#using-github-codespaces).  
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/SyneRBI/SIRF-Exercises)
 
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,8 @@ dependencies:
   - widgetsnbextension
   - nodejs
   - numpy
+  - cil # make synergistic notebooks work
+  - astra-toolbox # needed for ct examples
   - scipy
   - matplotlib
   - numba
@@ -21,6 +23,7 @@ dependencies:
   - imageio # nibabel dependency
   - tqdm
   - docopt
+  - pip
   - pip:
      - brainweb>=1.5.1
   # Developer dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,27 @@
+name: base
+channels:
+  - conda-forge
+  - ccpi
+  - defaults
+dependencies:
+  # Notebook dependencies
+  - ipywidgets
+  - ipympl
+  - widgetsnbextension
+  - nodejs
+  - numpy
+  - scipy
+  - matplotlib
+  - numba
+  - llvmlite  # numba dependency
+  - h5py
+  - nibabel
+  - scikit-image # nibabel dependency
+  - PyWavelets # nibabel dependency
+  - imageio # nibabel dependency
+  - tqdm
+  - docopt
+  - pip:
+     - brainweb>=1.5.1
+  # Developer dependencies
+  - nbstripout


### PR DESCRIPTION
This could work, but I cannot test it locally at the moment.

In GitHub Codespaces, I think I'm running out of quota (although my profile doesn't say that)
```

=================================================================================
2023-01-29 03:05:44.263Z: Configuration starting...
2023-01-29 03:05:44.302Z: Cloning...
2023-01-29 03:05:44.335Z: $ git -C "/var/lib/docker/codespacemount/workspace" clone --branch devcontainer --depth 1 https://github.com/SyneRBI/SIRF-Exercises "/var/lib/docker/codespacemount/workspace/SIRF-Exercises"
2023-01-29 03:05:44.357Z: Cloning into '/var/lib/docker/codespacemount/workspace/SIRF-Exercises'...
2023-01-29 03:05:45.951Z: git process exited with exit code 0
2023-01-29 03:05:45.958Z: $ git -C "/var/lib/docker/codespacemount/workspace/SIRF-Exercises" config --local remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
2023-01-29 03:05:45.971Z: git process exited with exit code 0

=================================================================================
2023-01-29 03:05:46.381Z: Creating container...
2023-01-29 03:05:46.386Z: $ devcontainer up --id-label Type=codespaces --workspace-folder /var/lib/docker/codespacemount/workspace/SIRF-Exercises --mount type=bind,source=/.codespaces/agent/mount/cache,target=/vscode --user-data-folder /var/lib/docker/codespacemount/.persistedshare --container-data-folder .vscode-remote/data/Machine --container-system-data-folder /var/vscode-remote --log-level trace --log-format json --update-remote-user-uid-default never --mount-workspace-git-root false --skip-non-blocking-commands --skip-post-create --config "/var/lib/docker/codespacemount/workspace/SIRF-Exercises/.devcontainer/devcontainer.json" --override-config /root/.codespaces/shared/merged_devcontainer.json --default-user-env-probe loginInteractiveShell --container-session-data-folder /workspaces/.codespaces/.persistedshare/devcontainers-cli/cache
2023-01-29 03:05:46.592Z: @devcontainers/cli 0.28.0. Node.js v14.21.2. linux 5.4.0-1100-azure x64.
2023-01-29 03:05:50.277Z: $ docker buildx build --load --build-arg BUILDKIT_INLINE_CACHE=1 -f /tmp/devcontainercli-root/container-features/0.28.0-1674961550236/Dockerfile-with-features -t vsc-sirf-exercises-21beb555f10f2af844bfe4bc7a170126 --target dev_containers_target_stage --build-arg _DEV_CONTAINERS_BASE_IMAGE=dev_container_auto_added_stage_label /var/lib/docker/codespacemount/workspace/SIRF-Exercises
2023-01-29 03:05:50.852Z: #1 [internal] load .dockerignore

<lots of stuff>

2023-01-29 03:08:48.096Z: #6 extracting sha256:88aac493923a537b93e5f6a7b98dd8d039732b09540532846e97165a9e78b008 41.0s
2023-01-29 03:08:50.899Z: #6 ERROR: failed to register layer: ApplyLayer exit status 1 stdout:  stderr: write /opt/SIRF-SuperBuild/sources/STIR/.git/objects/pack/pack-533e3cc9c31914b44fce2b84517557b78da90d7f.pack: no space left on device
2023-01-29 03:08:50.984Z: ------
 > [dev_container_auto_added_stage_label 1/3] FROM docker.io/synerbi/sirf:devel@sha256:6e8bd754994cfcdd1a9b0d0b06ed9ce0c5d2203f52c5b2c611bd4f90ba6cee4a:
```
Probably best to reduce our docker image size in any case.

Full log: [codespace.log](https://github.com/SyneRBI/SIRF-Exercises/files/10534776/codespace.log)
