### PR TITLE
Adding extensions, moving postCreateCommand to .sh file, and removing dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,0 @@
-FROM synerbi/sirf:devel-service
-

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,12 +12,7 @@
 	
 	// make sure we run our entrypoint.sh (to create users etc)
 	"overrideCommand": false,
-
-	"build": { 
-		"context": "..",
-		"dockerfile": "Dockerfile"
-	},
-
+	"image": "synerbi/sirf:devel-service",
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 
@@ -27,11 +22,14 @@
 	// Comment to connect as root instead.
 	"remoteUser": "jovyan",
 
-        "postCreateCommand": "mamba env update --file environment.yml && scripts/download_data.sh",
+    "postCreateCommand": "bash ./.devcontainer/postCreateCommand.sh",
 	// manual start of gadgetron, but commented-out as this is done in the service image
         // "postStartCommand": "nohup bash -c 'gadgetron >& /tmp/gadgetron.log &'"
 
 	// Configure tool-specific properties.
 	// "customizations": {},
+	"extensions": ["ms-python.python",
+		"ms-toolsai.jupyter",
+		"ms-python.vscode-pylance"]
 
 }

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,3 @@
+sed -i 's/\r$//' /workspaces/SIRF-Exercises/scripts/download_data.sh
+bash /workspaces/SIRF-Exercises/scripts/download_data.sh -m -p
+mamba env update --file environment.yml


### PR DESCRIPTION
So I tested this by running `notebooks/PET/reconstruct_measured_data.ipynb`. It did work and I made sure to run in VScode selecting the conda python kernel. Not sure if there is away of pre-configuring the kernel, [this](https://github.com/microsoft/vscode-jupyter/discussions/13032) seems related.

I found that there was an error when running `scripts/download_data.sh`:  `‘\r’: command not found`. So in .devcontainer/postCreateCommand.sh I included the line `sed -i 's/\r$//' /workspaces/SIRF-Exercises/scripts/download_data.sh`. I am not too sure the reason for this. I am cloning to my native Windows computer and then spinning this up through my WSL? The fix was taken from: [here](https://itslinuxfoss.com/fix-r-command-not-found-error/).