### PR TITLE
fix cil installation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 name: base
 channels:
   - conda-forge
+  - intel
   - ccpi
   - defaults
 dependencies:


### PR DESCRIPTION
add missing channel (to find CIL's `intel::ipp` dependency)