### PR TITLE
replace MR data used for intro/synergistic notebooks

### DIFF
--- a/notebooks/Introductory/acquisition_model_mr_pet_ct.ipynb
+++ b/notebooks/Introductory/acquisition_model_mr_pet_ct.ipynb
@@ -278,7 +278,7 @@
    "outputs": [],
    "source": [
     "# 1. create MR AcquisitionData\n",
-    "mr_acq = mr.AcquisitionData(os.path.join(examples_data_path('MR'),'grappa2_1rep.h5'))"
+    "mr_acq = mr.AcquisitionData(os.path.join(examples_data_path('MR'),'simulated_MR_2D_cartesian.h5'))"
    ]
   },
   {

--- a/notebooks/Synergistic/gradient_descent_mr_pet_ct.ipynb
+++ b/notebooks/Synergistic/gradient_descent_mr_pet_ct.ipynb
@@ -242,7 +242,7 @@
    "outputs": [],
    "source": [
     "# 1. create MR AcquisitionData\n",
-    "mr_acq = mr.AcquisitionData(examples_data_path('MR') + '/grappa2_1rep.h5')"
+    "mr_acq = mr.AcquisitionData(examples_data_path('MR') + '/simulated_MR_2D_cartesian.h5')"
    ]
   },
   {


### PR DESCRIPTION
The original data was created with an old ISMRMRD and it no longer seems to work.

See https://github.com/SyneRBI/SIRF/issues/1237