### PR TITLE
reduce memory & CPU requirement

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 //"postStartCommand": "nohup bash -c 'gadgetron >& /tmp/gadgetron.log &'" // already done in image
 "remoteUser": "jovyan",
 "portsAttributes": {"8888": {"label": "Jupyter", "onAutoForward": "notify"}},
-"postCreateCommand": "bash ./scripts/download_data.sh -m -p && mamba env update --file environment.yml",
+"postCreateCommand": "bash ./scripts/download_data.sh -m -p && sed -i /astra-toolbox/d environment.yml && mamba env update",
 // "features": {}, // https://containers.dev/features
 "customizations": {"vscode": {"extensions": [
 	"ms-python.python",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 "overrideCommand": false,
 //"postStartCommand": "nohup bash -c 'gadgetron >& /tmp/gadgetron.log &'" // already done in image
 "remoteUser": "jovyan",
-"portsAttributes": {"8888": {"label": "Jupyter", "onAutoForward": "notify"}},
+"portsAttributes": {"8888": {"label": "Jupyter", "onAutoForward": "ignore"}},
 "postCreateCommand": "bash ./scripts/download_data.sh -m -p && sed -i /astra-toolbox/d environment.yml && mamba env update",
 // "features": {}, // https://containers.dev/features
 "customizations": {"vscode": {"extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,35 +1,22 @@
-// For format details, see https://aka.ms/devcontainer.json.
+/// format: https://aka.ms/devcontainer.json
 {
-	"hostRequirements": {
- 	  "cpus": 4,
-   	  "memory": "8gb",
-	  // currently need more than 32gb to get the image to build
-   	  "storage": "32gb"
-	},
-	"name": "SIRF-Exercises",
-
-	// "initializeCommand": "docker system prune --all --force",
-	
-	// make sure we run our entrypoint.sh (to create users etc)
-	"overrideCommand": false,
-	"image": "ghcr.io/synerbi/sirf:jupyter",
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Comment to connect as root instead.
-	"remoteUser": "jovyan",
-
-    "postCreateCommand": "bash ./.devcontainer/postCreateCommand.sh",
-	// manual start of gadgetron, but commented-out as this is done in the service image
-        // "postStartCommand": "nohup bash -c 'gadgetron >& /tmp/gadgetron.log &'"
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-	"extensions": ["ms-python.python",
-		"ms-toolsai.jupyter",
-		"ms-python.vscode-pylance"]
-
+"hostRequirements": {
+	"cpus": 4,
+	"memory": "8gb",
+	"storage": "32gb"
+},
+"name": "SIRF-Exercises",
+//"initializeCommand": "docker system prune --all --force",
+"image": "ghcr.io/synerbi/sirf:jupyter",
+/// use image's entrypoint & user
+"overrideCommand": false,
+//"postStartCommand": "nohup bash -c 'gadgetron >& /tmp/gadgetron.log &'" // already done in image
+"remoteUser": "jovyan",
+"portsAttributes": {"8888": {"label": "Jupyter", "onAutoForward": "notify"}},
+"postCreateCommand": "bash ./scripts/download_data.sh -m -p && mamba env update --file environment.yml",
+// "features": {}, // https://containers.dev/features
+"customizations": {"vscode": {"extensions": [
+	"ms-python.python",
+	"ms-toolsai.jupyter",
+	"ms-python.vscode-pylance"]}}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
  	  "cpus": 4,
    	  "memory": "8gb",
 	  // currently need more than 32gb to get the image to build
-   	  "storage": "64gb"
+   	  "storage": "32gb"
 	},
 	"name": "SIRF-Exercises",
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 /// format: https://aka.ms/devcontainer.json
 {
 "hostRequirements": {
-	"cpus": 4,
+	"cpus": 2,
 	"memory": "8gb",
 	"storage": "32gb"
 },

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,2 +1,0 @@
-bash /workspaces/SIRF-Exercises/scripts/download_data.sh -m -p
-mamba env update --file environment.yml

--- a/DocForParticipants.md
+++ b/DocForParticipants.md
@@ -24,7 +24,7 @@ This instruction contain documentation and links to get started with the exercis
 - [Appendix of useful info](#appendix)
 
 The SIRF documentation can be found [here](https://github.com/SyneRBI/SIRF/wiki/Software-Documentation).
-***The current version of these exercises needs SIRF v3.4.0.*** Some exercises could still work on SIRF v3.2.0 (SPECT needs v3.3.0).
+***The current version of these exercises needs SIRF v3.6.0.*** Some exercises could still work on SIRF v3.4.0 (SPECT needs v3.3.0).
 
 Documentation is in the form of MarkDown files (`*.md`), which are simple text files which you open from the Jupyter notebook, but they look nicer when browsing to [GitHub](https://github.com/SyneRBI/SIRF-Exercises/tree/master/).
 
@@ -42,12 +42,12 @@ A useful introduction to the notebook interface [can be found here](http://jupyt
 
 There are several ways to get SIRF and its exercises running for the training course. 
 
-1. Accessing a remote server prepared for the training course (could be Azure, STFC cloud or others). This is specific for organized training courses. Please check with your instructors. 
+1. Accessing a remote server with everything prepared. This is currently continuously available via GitHub Codespaces. However,if you are attending  organized training courses, this will be organised for you(could be Azure, STFC cloud or something else). Please check with your instructors.
 2. Installing and running the SIRF Virtual Machine (VM).
 3. Installing and running the SIRF Docker image.
 4. Installing and building SIRF and the SIRF-Exercises on your machine from source.
 
-We recommend that if you are installing this for a training course, you use any of the first three options, as installing SIRF from source is harder than the rest.
+We recommend that initially you use one of the first three options, as installing SIRF from source is harder than the rest.
 The VM works well in any operating system, Docker works well in Linux and MacOS, or on Windows in a Linux installation under WSL (native Windows support for our Docker images is currently untested).
 
 Instructions for all (except the training course specific server, as this will be given in the training course) can be found at https://github.com/SyneRBI/SIRF/wiki/How-to-obtain-SIRF.
@@ -78,7 +78,7 @@ installation of all dependencies and downloading the example data.
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/SyneRBI/SIRF-Exercises)
 
 Some notes:
-- When selecting a kernel, please use the `conda` python (not `/usr/bin/python3`).
+- You will have to select a Python kernel for each notebook (top-right). Please use the existing `conda` python kernel (**not** `/usr/bin/python3`) listed in "Python environments". Alternatively, you can access the jupyter server running in the codespace via [port forwarding](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace).
 - You might want to conserve some resources by manually
 [stopping a code space](https://docs.github.com/en/codespaces/developing-in-codespaces/stopping-and-starting-a-codespace),
 otherwise GitHub will stop it for you after a certain time-out. You can then restart the codespace to resume your work.
@@ -115,7 +115,7 @@ If this fails, you could try to use web browser in the VM instead.
 
 ### Using Docker
 
-The instructions to start Docker and SIRF are documented in the [Docker instructions at SIRF](https://github.com/SyneRBI/SIRF-SuperBuild/blob/master/docker/README.md), please follow those to start it. 
+The instructions to start Docker and SIRF are documented in the [Docker instructions at SIRF-Superbuild](https://github.com/SyneRBI/SIRF-SuperBuild/blob/master/docker/README.md), please follow those to start it. 
 Docker is easiest in Linux, MacOS or Windows+WSL. If you are not familiar with Docker, you could use the VM instead. 
 
 Please note that for at present (at least up to SIRF 3.6), you need to point your (host) web-browser to http://localhost:9999 (fill in the 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,10 @@
 # SIRF-Exercises
 
-This material is intended for practical demonstrations using 
-[SIRF](https://github.com/SyneRBI/SIRF/wiki/Software-Documentation) on PET, SPECT and MR Image Reconstruction, including synergistic aspects.
+This material is intended to get you going with
+[SIRF](https://github.com/SyneRBI/SIRF/wiki/Software-Documentation),
+an open source framework for PET, SPECT and MR Image Reconstruction, including synergistic aspects.
 
-This repository contains exercises to get you going
-with SIRF. 
-There is also some basic information on [CIL](https://www.ccpi.ac.uk/CIL) functionality to show similarities with SIRF.
-
-Authors:
-- Kris Thielemans (this document and PET exercises)
-- Christoph Kolbitsch (MR exercises)
-- Johannes Mayer (MR exercises)
-- David Atkinson (MR and geometry exercises)
-- Evgueni Ovtchinnikov (PET and MR exercises)
-- Edoardo Pasca (overall check and clean-up)
-- Richard Brown (PET and registration exercises)
-- Daniel Deidda and Palak Wadhwa (HKEM exercise)
-- Ashley Gillman (overall check, scripts and clean-up)
-- Imraj Singh (Deep Learning for PET exercise)
-- Daniel Deidda and Sam Porter (Synergistic SPECT/PET Reconstruction Exercises)
+This repository also contains basic information on [CIL](https://www.ccpi.ac.uk/CIL) functionality to show similarities with SIRF and how use CIL's optimisation algorithms.
 
 This software is distributed under an open source license, see [LICENSE.txt](LICENSE.txt)
 for details.
@@ -28,7 +14,7 @@ for details.
 Full instructions on getting started are in our [documentation for participants](DocForParticipants.md)
 (or use [this link to GitHub](https://github.com/SyneRBI/SIRF-Exercises/blob/master/DocForParticipants.md)
 for nice formatting, but do check which version of the exercises you are using). Despite the name,
-this documentation is also appropriate if you are trying these exercises on your own.
+this documentation is also appropriate if you are trying these exercises on your own.  
 *Gentle request*:
 If you are attending a course, ***please read this before the course.*** 
 
@@ -36,8 +22,21 @@ Instructors should check our [documentation for instructors](https://github.com/
 
 Installation instructions when you do not use our cloud resources are in [INSTALL.md](INSTALL.md), but read the above links first.
 
-You can run the SIRF-Exercises in GitHub Codespaces, see [the section in the documentation](DocForParticipants.md#using-github-codespaces).  
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/SyneRBI/SIRF-Exercises)
+You can run the SIRF-Exercises in GitHub Codespaces, see [the section in the documentation](DocForParticipants.md#using-github-codespaces), including information on which kernel to select (and more!).
+
+# Authors
+
+- Kris Thielemans (this document and PET exercises)
+- Christoph Kolbitsch (MR exercises and Introductory exercises)
+- Johannes Mayer (MR exercises)
+- David Atkinson (MR and geometry exercises)
+- Evgueni Ovtchinnikov (PET and MR exercises)
+- Edoardo Pasca (overall check and clean-up)
+- Richard Brown (PET and registration exercises)
+- Daniel Deidda and Palak Wadhwa (HKEM exercise)
+- Ashley Gillman (overall check, scripts and clean-up)
+- Imraj Singh (Deep Learning for PET exercise)
+- Daniel Deidda and Sam Porter (Synergistic SPECT/PET Reconstruction Exercises)
 
 
 


### PR DESCRIPTION
- [x] allows selecting a free-tier GH Codespace machine
  + 64 -> 32GB disk
  + 4 -> 2 CPU cores
- [x] tidy up devcontainer spec
  + add `8888` port forward
  + drop ASTRA (GPU) dependency & implicit CUDA Toolkit (saves ~800MB and ~5min `postCreate`)
  + `extensions` -> `customizations.vscode.extensions`
  + drop separate `postCreateCommand.sh`
- [x] test before merging
- [ ] `apt remove python3`?