### PR TITLE
use `:latest` image

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -7,7 +7,7 @@
 },
 "name": "SIRF-Exercises",
 //"initializeCommand": "docker system prune --all --force",
-"image": "ghcr.io/synerbi/sirf:jupyter",
+"image": "ghcr.io/synerbi/sirf:latest",
 /// use image's entrypoint & user
 "overrideCommand": false,
 //"postStartCommand": "nohup bash -c 'gadgetron >& /tmp/gadgetron.log &'" // already done in image


### PR DESCRIPTION
Since https://github.com/SyneRBI/SIRF-SuperBuild/releases/tag/v3.6.0 the `latest` image is now up-to-date