### PR TITLE
remove intel anaconda channel

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 name: base
 channels:
   - conda-forge
-  - intel
+  - https://software.repos.intel.com/python/conda
   - ccpi
   - defaults
 dependencies:


### PR DESCRIPTION
Due to intel removing the `intel` anaconda channel https://github.com/TomographicImaging/CIL/issues/1856