### PR TITLE
devcontainer: pin to SIRF docker image used by PETRIC 2024

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -7,7 +7,7 @@
 },
 "name": "SIRF-Exercises",
 //"initializeCommand": "docker system prune --all --force",
-"image": "ghcr.io/synerbi/sirf:latest",
+"image": "ghcr.io/synerbi/sirf:petric-base",
 /// use image's entrypoint & user
 "overrideCommand": false,
 //"postStartCommand": "nohup bash -c 'gadgetron >& /tmp/gadgetron.log &'" // already done in image


### PR DESCRIPTION
This is identical to https://github.com/SyneRBI/PETRIC-backend/blob/2b19c634fde2db4e908ba68d4320dc9e613c54d0/Dockerfile#L2-L3