### PR TITLE
mark gpu optional

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -3,7 +3,8 @@
 "hostRequirements": {
 	"cpus": 2,
 	"memory": "8gb",
-	"storage": "32gb"
+	"storage": "32gb",
+	"gpu": "optional"
 },
 "name": "SIRF-Exercises",
 //"initializeCommand": "docker system prune --all --force",


### PR DESCRIPTION
with `"gpu": "optional"`, the only potential user change needed to get a GPU is `"runArgs": ["--gpus=all"]`.

(IMO this is a bug, they should make `"gpu": "optional"` automagically append `--gpus=all` https://github.com/microsoft/vscode-remote-release/issues/6989)