### PR TITLE
devcontainer: GPU & CPU

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -9,7 +9,7 @@
 "runArgs": ["--gpus=all"],
 "name": "SIRF-Exercises",
 //"initializeCommand": "docker system prune --all --force",
-"image": "ghcr.io/synerbi/sirf:petric-base",
+"image": "ghcr.io/synerbi/sirf:petric",
 /// use image's entrypoint & user
 "overrideCommand": false,
 //"postStartCommand": "nohup bash -c 'gadgetron >& /tmp/gadgetron.log &'" // already done in image

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -6,6 +6,7 @@
 	"storage": "32gb",
 	"gpu": "optional"
 },
+"runArgs": ["--gpus=all"],
 "name": "SIRF-Exercises",
 //"initializeCommand": "docker system prune --all --force",
 "image": "ghcr.io/synerbi/sirf:petric-base",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,13 +3,11 @@
 "hostRequirements": {
 	"cpus": 2,
 	"memory": "8gb",
-	"storage": "32gb",
-	"gpu": "optional"
+	"storage": "32gb"
 },
-"runArgs": ["--gpus=all"],
 "name": "SIRF-Exercises",
 //"initializeCommand": "docker system prune --all --force",
-"image": "ghcr.io/synerbi/sirf:petric",
+"image": "ghcr.io/synerbi/sirf:petric-base",
 /// use image's entrypoint & user
 "overrideCommand": false,
 //"postStartCommand": "nohup bash -c 'gadgetron >& /tmp/gadgetron.log &'" // already done in image

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -1,0 +1,24 @@
+/// format: https://aka.ms/devcontainer.json
+{
+"hostRequirements": {
+	"cpus": 2,
+	"memory": "8gb",
+	"storage": "32gb",
+	"gpu": {"cores": 100, "storage": "2gb"}
+},
+"runArgs": ["--gpus=all"],
+"name": "SIRF-Exercises",
+//"initializeCommand": "docker system prune --all --force",
+"image": "ghcr.io/synerbi/sirf:petric",
+/// use image's entrypoint & user
+"overrideCommand": false,
+//"postStartCommand": "nohup bash -c 'gadgetron >& /tmp/gadgetron.log &'" // already done in image
+"remoteUser": "jovyan",
+"portsAttributes": {"8888": {"label": "Jupyter", "onAutoForward": "ignore"}},
+"postCreateCommand": "bash ./scripts/download_data.sh -m -p && sed -i /astra-toolbox/d environment.yml && mamba env update",
+// "features": {}, // https://containers.dev/features
+"customizations": {"vscode": {"extensions": [
+	"ms-python.python",
+	"ms-toolsai.jupyter",
+	"ms-python.vscode-pylance"]}}
+}

--- a/DocForParticipants.md
+++ b/DocForParticipants.md
@@ -75,7 +75,9 @@ The free allocation should be enough to get you familiar with SIRF.
 Note that the creation of the codespace will take around 5 minutes. This includes creation of the container,
 installation of all dependencies and downloading the example data.
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/SyneRBI/SIRF-Exercises)
+[![CPU Codespace](https://img.shields.io/badge/Codespaces-CPU-blue?logo=github)](https://codespaces.new/SyneRBI/SIRF-Exercises)
+
+[![GPU Codespace](https://img.shields.io/badge/Codespaces-GPU-green?logo=github)](https://codespaces.new/casperdcl/SIRF-Exercises?devcontainer_path=.devcontainer%2Fgpu%2Fdevcontainer.json&geo=UsEast&machine=standardLinuxNcv3)
 
 Some notes:
 - You will have to select a Python kernel for each notebook (top-right). Please use the existing `conda` python kernel (**not** `/usr/bin/python3`) listed in "Python environments". Alternatively, you can access the jupyter server running in the codespace via [port forwarding](https://docs.github.com/en/codespaces/developing-in-a-codespace/forwarding-ports-in-your-codespace).


### PR DESCRIPTION
- separate GPU config with `--gpus=all` & full PETRIC image with torch & tensorflow
- vis. https://github.com/microsoft/vscode-remote-release/issues/6989#issuecomment-2990066319
  + still missing ability to prebuild both, so continue to use my fork for GPU prebuilds...

