### PR TITLE
drop mamba env update

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 //"postStartCommand": "nohup bash -c 'gadgetron >& /tmp/gadgetron.log &'" // already done in image
 "remoteUser": "jovyan",
 "portsAttributes": {"8888": {"label": "Jupyter", "onAutoForward": "ignore"}},
-"postCreateCommand": "bash ./scripts/download_data.sh -m -p && sed -i /astra-toolbox/d environment.yml && mamba env update",
+"postCreateCommand": "bash ./scripts/download_data.sh -m -p",
 // "features": {}, // https://containers.dev/features
 "customizations": {"vscode": {"extensions": [
 	"ms-python.python",

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -15,7 +15,7 @@
 //"postStartCommand": "nohup bash -c 'gadgetron >& /tmp/gadgetron.log &'" // already done in image
 "remoteUser": "jovyan",
 "portsAttributes": {"8888": {"label": "Jupyter", "onAutoForward": "ignore"}},
-"postCreateCommand": "bash ./scripts/download_data.sh -m -p && sed -i /astra-toolbox/d environment.yml && mamba env update",
+"postCreateCommand": "bash ./scripts/download_data.sh -m -p",
 // "features": {}, // https://containers.dev/features
 "customizations": {"vscode": {"extensions": [
 	"ms-python.python",


### PR DESCRIPTION
I manually checked that all `environment.yml` deps are already in the image.

Obviously they must be in the image because of https://github.com/SyneRBI/SIRF-SuperBuild/blob/master/docker/user_demos.sh