### PR TITLE
slight devcontainer tidy

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,11 @@
 	"storage": "32gb"},
 "name": "SIRF-Exercises (CPU)",
 "image": "ghcr.io/synerbi/sirf:latest",
-"overrideCommand": false, // use docker-stacks command, vis also https://aka.ms/dev-containers-non-root
+/// https://aka.ms/dev-containers-non-root
+"overrideCommand": false, // use docker-stacks command
+"runArgs": [
+	"--user=1000:${localEnv:GROUPS}", // you may have to hardcode replace `${localEnv:GROUPS}` with your local group ID to fix workspace access permissions
+	"--group-add=users"],
 "forwardPorts": [8888, 9002],
 "portsAttributes": {
 	"8888": {"label": "Jupyter", "requireLocalPort": true, "onAutoForward": "ignore"},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,22 +1,25 @@
 /// format: https://aka.ms/devcontainer.json
+/// config: https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose
+/// example: https://github.com/devcontainers-community/templates-jupyter-datascience-notebooks/tree/main/.devcontainer
 {
 "hostRequirements": {
 	"cpus": 2,
 	"memory": "8gb",
-	"storage": "32gb"
-},
+	"storage": "32gb"},
 "name": "SIRF-Exercises (CPU)",
-//"initializeCommand": "docker system prune --all --force",
 "image": "ghcr.io/synerbi/sirf:latest",
-/// use image's entrypoint & user
-"overrideCommand": false,
-//"postStartCommand": "nohup bash -c 'gadgetron >& /tmp/gadgetron.log &'" // already done in image
-"remoteUser": "jovyan",
-"portsAttributes": {"8888": {"label": "Jupyter", "onAutoForward": "ignore"}},
+"overrideCommand": false, // use docker-stacks command, vis also https://aka.ms/dev-containers-non-root
+"forwardPorts": [8888, 9002],
+"portsAttributes": {
+	"8888": {"label": "Jupyter", "requireLocalPort": true, "onAutoForward": "ignore"},
+	"9002": {"label": "Gadgetron", "onAutoForward": "silent"}},
 "postCreateCommand": "bash ./scripts/download_data.sh -m -p",
 // "features": {}, // https://containers.dev/features
-"customizations": {"vscode": {"extensions": [
-	"ms-python.python",
-	"ms-toolsai.jupyter",
-	"ms-python.vscode-pylance"]}}
+"customizations": {"vscode": {
+	"settings": {
+		"python.defaultInterpreterPath": "/opt/conda/bin/python"},
+	"extensions": [
+		"ms-python.python",
+		"ms-toolsai.jupyter",
+		"ms-python.vscode-pylance"]}}
 }

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -7,10 +7,14 @@
 	"memory": "8gb",
 	"storage": "32gb",
 	"gpu": {"cores": 100, "storage": "2gb"}},
-"runArgs": ["--gpus=all"],
 "name": "SIRF-Exercises (GPU)",
 "image": "ghcr.io/synerbi/sirf:latest-gpu",
-"overrideCommand": false, // use docker-stacks command, vis also https://aka.ms/dev-containers-non-root
+/// https://aka.ms/dev-containers-non-root
+"overrideCommand": false, // use docker-stacks command
+"runArgs": [
+	"--gpus=all",
+	"--user=1000:${localEnv:GROUPS}", // you may have to hardcode replace `${localEnv:GROUPS}` with your local group ID to fix workspace access permissions
+	"--group-add=users"],
 "forwardPorts": [8888, 9002],
 "portsAttributes": {
 	"8888": {"label": "Jupyter", "requireLocalPort": true, "onAutoForward": "ignore"},

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -1,24 +1,27 @@
 /// format: https://aka.ms/devcontainer.json
+/// config: https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose
+/// example: https://github.com/devcontainers-community/templates-jupyter-datascience-notebooks/tree/main/.devcontainer
 {
 "hostRequirements": {
 	"cpus": 2,
 	"memory": "8gb",
 	"storage": "32gb",
-	"gpu": {"cores": 100, "storage": "2gb"}
-},
+	"gpu": {"cores": 100, "storage": "2gb"}},
 "runArgs": ["--gpus=all"],
 "name": "SIRF-Exercises (GPU)",
-//"initializeCommand": "docker system prune --all --force",
 "image": "ghcr.io/synerbi/sirf:latest-gpu",
-/// use image's entrypoint & user
-"overrideCommand": false,
-//"postStartCommand": "nohup bash -c 'gadgetron >& /tmp/gadgetron.log &'" // already done in image
-"remoteUser": "jovyan",
-"portsAttributes": {"8888": {"label": "Jupyter", "onAutoForward": "ignore"}},
+"overrideCommand": false, // use docker-stacks command, vis also https://aka.ms/dev-containers-non-root
+"forwardPorts": [8888, 9002],
+"portsAttributes": {
+	"8888": {"label": "Jupyter", "requireLocalPort": true, "onAutoForward": "ignore"},
+	"9002": {"label": "Gadgetron", "onAutoForward": "silent"}},
 "postCreateCommand": "bash ./scripts/download_data.sh -m -p",
 // "features": {}, // https://containers.dev/features
-"customizations": {"vscode": {"extensions": [
-	"ms-python.python",
-	"ms-toolsai.jupyter",
-	"ms-python.vscode-pylance"]}}
+"customizations": {"vscode": {
+	"settings": {
+		"python.defaultInterpreterPath": "/opt/conda/bin/python"},
+	"extensions": [
+		"ms-python.python",
+		"ms-toolsai.jupyter",
+		"ms-python.vscode-pylance"]}}
 }


### PR DESCRIPTION
- auto-detect container user
- set path to python
- cite sources e.g. [docker-stacks at devcontainers-community](https://github.com/devcontainers-community/templates-jupyter-datascience-notebooks/tree/main/.devcontainer)
- label gadgetron port
- document local group ID permission work-around
- [x] test locally (VSCode)
- [x] test GitHub Codespaces (CPU)